### PR TITLE
fix: erroneous geometry updates

### DIFF
--- a/Example Project/Example Project.xcodeproj/project.pbxproj
+++ b/Example Project/Example Project.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Debug;
 		};
@@ -354,6 +355,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;
 		};

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "VisionPanes",
+    platforms: [
+        .visionOS(.v1)
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/VisionPanes/MultiPaneView.swift
+++ b/Sources/VisionPanes/MultiPaneView.swift
@@ -31,8 +31,13 @@ struct MultiPaneView<Item, MainView, PaneView>: UIViewControllerRepresentable wh
         uiViewController.item = item
         uiViewController.configuration = configuration
         
-        uiViewController._updateWindowGeometry()
+        // Make sure the item has changed when updating geometry
+        if uiViewController.item?.id != uiViewController.previousItem?.id {
+            uiViewController._updateWindowGeometry()
+        }
         
+        uiViewController.previousItem = item
+            
         uiViewController.paneController?.rootView = paneView()
     }
 }

--- a/Sources/VisionPanes/MultiPaneViewController.swift
+++ b/Sources/VisionPanes/MultiPaneViewController.swift
@@ -43,6 +43,8 @@ class MultiPaneViewController<Item, MainView, PaneView>: UIViewController where 
         guard let window = view.window else { return }
         guard let scene = window.windowScene else { return }
         
+        guard item?.id != previousItem?.id else { return }
+        
         let geo = UIWindowScene.GeometryPreferences.Vision()
         
         geo.size = window.bounds.size


### PR DESCRIPTION
Added a check to see if geometry updates are necessary. Specifically, they are only necessary when the item binding changes. 